### PR TITLE
Fix command checks in bootstrap script

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e          # Exit on error
 set -u          # Treat unset variables as an error
@@ -10,12 +10,10 @@ echo "🚀 Starting bootstrap script..."
 cd "$(dirname "$0")"
 
 # --- 1. Install Nix ---
-if
-  ! command -v nix &
-  >/dev/null
-then
+if ! command -v nix >/dev/null; then
   echo "📦 Installing Nix..."
   curl -L https://nixos.org/nix/install | sh
+  # shellcheck disable=SC1090
   . ~/.nix-profile/etc/profile.d/nix.sh
 else
   echo "✅ Nix is already installed."
@@ -29,10 +27,7 @@ experimental-features = nix-command flakes
 EOF
 
 # --- 3. Install nix-darwin ---
-if
-  ! command -v sudo darwin-rebuild &
-  >/dev/null
-then
+if ! command -v darwin-rebuild >/dev/null; then
   echo "🍏 Installing nix-darwin..."
   nix run nixpkgs#darwin-rebuild switch --flake .#MacBook-Pro
 else
@@ -47,11 +42,8 @@ sudo darwin-rebuild switch --flake .#MacBook-Pro
 echo "✅ Installation complete! Verifying setup..."
 nix --version
 
-if
-  command -v sudo darwin-rebuild &
-  >/dev/null
-then
-  echo "✅ nix-darwin is installed: $(command -v sudo darwin-rebuild)"
+if command -v darwin-rebuild >/dev/null; then
+  echo "✅ nix-darwin is installed: $(command -v darwin-rebuild)"
 else
   echo "❌ nix-darwin is not installed!"
 fi


### PR DESCRIPTION
## Summary
- correct `command -v` usage in bootstrap script
- properly detect nix-darwin and nix availability
- run bootstrap script with bash and silence shellcheck warning

## Testing
- `shellcheck bootstrap.sh`


------
https://chatgpt.com/codex/tasks/task_e_6895a98323508333ab41c883832fc9ee