### PR TITLE
Fix ghostty config path

### DIFF
--- a/home-manager/dotfiles.nix
+++ b/home-manager/dotfiles.nix
@@ -1,7 +1,7 @@
 args: {
   home = {
     # file."./.warp/themes/norly.yaml".source = ./config/themes/warp/norly.yaml;
-    file."./.config/ghostty/config".source = ./config/ghostty;
+    file.".config/ghostty/config".source = ./config/ghostty;
     #file.".config/fish/conf.d/nix-env.fish".source = ./config/nix-env.fish;
   };
 }


### PR DESCRIPTION
## Summary
- remove leading ./ from ghostty config path

## Testing
- `nix flake check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895bd17f71883339afae76850ce1ebf