### PR TITLE
Add Nix formatter and dev shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ This repository contains my personal dotfiles, customized for setting up and man
      sudo darwin-rebuild switch --flake ~/Projects/dots#MacBook-Pro
      ```
 
+3. **Development Shell and Formatting**
+
+   - Enter a development environment with tools like `nixd`, `nixfmt` and `shellcheck`:
+
+     ```bash
+     nix develop
+     ```
+
+   - Format all Nix files in the repository:
+
+     ```bash
+     nix fmt
+     ```
+
 ---
 
 ### Dependencies

--- a/flake.nix
+++ b/flake.nix
@@ -60,12 +60,29 @@
         };
         gpgKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDKMrSvVp0l9fKINnGygXRyjoV2kwmZalbWYfOuP/rfHT1t62xL/daZi4w9K/ucS9wQvXkxEaPwiIg7tqfjI4rTjl77WeZVd/sawiRtKBXyTsjjOC81NB0EpgDnv9hU1cggYDOtUE2EwWSjdmAHaG88uR6BxYOhG54A9KOBWYdgreIPzfYhM/CO5ukWs8wVdi9bCmGiADR0h3O0/oxvfDzZiMsU4+blzkjFEOEG0Je9SwbWy3dmRsiL70amny3EDjrMWpv4VmapWpSwwNvau5kX+X0d+KBejmNjE94tegASqAi2ynLbm2A/YhmMzyvCHgME5UVG3fP15dd6QSbFC7T938KtHiT1AOm+pYd04Xn/XqWVY9aa8arL/ChHQnPPXR85JFnTtkSr3w4UowPZrtf7Io+ISXA5TrBONYlcHzZ63d2TraW6Kq71/hfw/OVLnIsEHSHV5Vv2Etm4aM5xWPRhDfoJRoI0dolExpkdq358A2DxkKAIj8PLdw/fErbtRBVFHMw63juhpL3quQKg+qRZ/A6ZtwCR3qkWkhN7QXrKE7ZR0PtwstBBinrwx7VS2Gp4FGrfD87yMiM/DvY4huUKvif+sZL0b6U933OpiRM9EXLQzKNnS3oflAw4sgI/r+syPRGKyV1+1KyT5OK2ldKGMDkDsIcIR3yzzs1/pQsPew==";
       };
-      pkgs = import nixpkgs {
-        inherit (machineConfig) system;
+      systems = nixpkgs.lib.systems.flakeExposed;
+      pkgsFor = system: import nixpkgs {
+        inherit system;
         config.allowUnfree = true;
       };
+      pkgs = pkgsFor machineConfig.system;
     in
     {
+      formatter = nixpkgs.lib.genAttrs systems (system: (pkgsFor system).nixfmt-rfc-style);
+
+      devShells = nixpkgs.lib.genAttrs systems (system:
+        let
+          pkgs = pkgsFor system;
+        in {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              nixd
+              nixfmt-rfc-style
+              shellcheck
+            ];
+          };
+        });
+
       darwinConfigurations.${machineConfig.hostname} = nix-darwin.lib.darwinSystem {
         inherit (machineConfig) system;
         inherit pkgs;


### PR DESCRIPTION
## Summary
- expose nixfmt as flake formatter for all systems
- provide development shell with nix tooling
- document `nix develop` and `nix fmt`

## Testing
- `nix --extra-experimental-features 'nix-command flakes' flake check`
- `nix --extra-experimental-features 'nix-command flakes' fmt` *(fails: unable to download 'https://ftpmirror.gnu.org/bash/bash-5.3.tar.gz')*


------
https://chatgpt.com/codex/tasks/task_e_6895c32f9dd08333b20a300026a0d0b2