### PR TITLE
refactor shell aliases into shared module

### DIFF
--- a/home-manager/config/aliases.nix
+++ b/home-manager/config/aliases.nix
@@ -1,4 +1,4 @@
-{
+rec {
   shellAliases = {
     sudo = "sudo ";
     mkdir = "mkdir -pv";
@@ -22,7 +22,7 @@
     cya = "dots ; sudo shutdown -h now";
     up = "cd $DOTFILES && nix flake check && nix flake update && sudo darwin-rebuild switch --flake .#MacBook-Pro && cd -";
     c = "code";
-    pullall = "find . -mindepth 1 -maxdepth 1 -type d -exec git --git-dir={}/.git --work-tree=$PWD/{} pull origin master \\;";
+    pullall = "find . -mindepth 1 -maxdepth 1 -type d -exec git --git-dir={}/.git --work-tree=$PWD/{} pull origin master \;";
     myip = "curl ipinfo.io/ip";
     ports = "netstat -t -u -l -a -n";
     lg = "lazygit";
@@ -31,9 +31,37 @@
 
   functions = {
     fish = {
-      mkcd = "function mkcd; if test (count $argv) -gt 0; mkdir $argv[1]; cd $argv[1]; end; end";
-      skub = "function skub; git pull; git add -A; if test (count $argv) -gt 0; git commit -m $argv[1]; else; git commit -m '.'; end; git push; end";
-      to = "function to; if test (count $argv) -gt 1; unoconv -f $argv[1] $argv[2]; else if test (count $argv) -eq 1; echo 'Need to specify file to convert....'; else; echo 'Need to specify what to convert to...'; end; end; end";
+      mkcd = ''
+        function mkcd
+          if test (count $argv) -gt 0
+            mkdir $argv[1]
+            cd $argv[1]
+          end
+        end
+      '';
+      skub = ''
+        function skub
+          git pull
+          git add -A
+          if test (count $argv) -gt 0
+            git commit -m $argv[1]
+          else
+            git commit -m '.'
+          end
+          git push
+        end
+      '';
+      to = ''
+        function to
+          if test (count $argv) -gt 1
+            unoconv -f $argv[1] $argv[2]
+          else if test (count $argv) -eq 1
+            echo 'Need to specify file to convert....'
+          else
+            echo 'Need to specify what to convert to...'
+          end
+        end
+      '';
     };
 
     zsh = ''

--- a/home-manager/config/aliases.nix
+++ b/home-manager/config/aliases.nix
@@ -1,0 +1,72 @@
+{ }:
+
+{
+  shellAliases = {
+    sudo = "sudo ";
+    mkdir = "mkdir -pv";
+    mv = "mv -iv";
+    cp = "cp -iv";
+    du = "ncdu --color dark -rr -x --exclude .git --exclude node_modules";
+    rm = "trash";
+    ping = "prettyping";
+    cat = "bat --theme Nord";
+    vim = "nvim";
+    vi = "nvim";
+    grep = "rg";
+    vscode = "code";
+    o = "open";
+    zshconfig = "vi ~/.zshrc ; echo 'Sourcing zsh file' ; source ~/.zshrc";
+    neofetch = "clear && neofetch | lolcat";
+    cmatrix = "cmatrix -C green";
+    dots = "git -C $DOTFILES add -A ; git -C $DOTFILES commit -m 'Changed stuff' ; git -C $DOTFILES push";
+    reboot = "sudo reboot";
+    sl = "sl | lolcat";
+    cya = "dots ; sudo shutdown -h now";
+    up = "cd $DOTFILES && nix flake check && nix flake update && sudo darwin-rebuild switch --flake .#MacBook-Pro && cd -";
+    c = "code";
+    pullall = "find . -mindepth 1 -maxdepth 1 -type d -exec git --git-dir={}/.git --work-tree=$PWD/{} pull origin master \\;";
+    myip = "curl ipinfo.io/ip";
+    ports = "netstat -t -u -l -a -n";
+    lg = "lazygit";
+    g = "git";
+  };
+
+  functions = {
+    fish = {
+      mkcd = "function mkcd; if test (count $argv) -gt 0; mkdir $argv[1]; cd $argv[1]; end; end";
+      skub = "function skub; git pull; git add -A; if test (count $argv) -gt 0; git commit -m $argv[1]; else; git commit -m '.'; end; git push; end";
+      to = "function to; if test (count $argv) -gt 1; unoconv -f $argv[1] $argv[2]; else if test (count $argv) -eq 1; echo 'Need to specify file to convert....'; else; echo 'Need to specify what to convert to...'; end; end; end";
+    };
+
+    zsh = ''
+      function mkcd() {
+          if [[ "$1" ]]; then
+              mkdir "$1" && cd "$1"
+          fi
+      }
+
+      function skub() {
+          git pull
+          git add -A
+          if [ "$1" != "" ]; then
+              git commit -m "$1"
+          else
+              git commit -m "."
+          fi
+          git push
+      }
+
+      function to() {
+          if [ "$1" != "" ]; then
+              if [ "$2" != "" ]; then
+                  unoconv -f "$1" "$2"
+              else
+                  echo "Need to specify file to convert...."
+              fi
+          else
+              echo "Need to specify what to convert to..."
+          fi
+      }
+    '';
+  };
+}

--- a/home-manager/config/aliases.nix
+++ b/home-manager/config/aliases.nix
@@ -1,5 +1,3 @@
-{ }:
-
 {
   shellAliases = {
     sudo = "sudo ";

--- a/home-manager/config/fish.nix
+++ b/home-manager/config/fish.nix
@@ -1,4 +1,7 @@
 { ... }:
+let
+  inherit (import ./aliases.nix) shellAliases functions;
+in
 {
   programs.fish = {
     enable = true;
@@ -17,40 +20,7 @@
       end
     '';
 
-    shellAliases = {
-      sudo = "sudo ";
-      mkdir = "mkdir -pv";
-      mv = "mv -iv";
-      cp = "cp -iv";
-      du = "ncdu --color dark -rr -x --exclude .git --exclude node_modules";
-      rm = "trash";
-      ping = "prettyping";
-      cat = "bat --theme Nord";
-      vim = "nvim";
-      vi = "nvim";
-      grep = "rg";
-      vscode = "code";
-      o = "open";
-      zshconfig = "vi ~/.zshrc ; echo 'Sourcing zsh file' ; source ~/.zshrc";
-      neofetch = "clear && neofetch | lolcat";
-      cmatrix = "cmatrix -C green";
-      dots = "git -C $DOTFILES add -A ; git -C $DOTFILES commit -m 'Changed stuff' ; git -C $DOTFILES push";
-      reboot = "sudo reboot";
-      sl = "sl | lolcat";
-      cya = "dots ; sudo shutdown -h now";
-      up = "cd $DOTFILES && nix flake check && nix flake update && sudo darwin-rebuild switch --flake .#MacBook-Pro && cd -";
-      c = "code";
-      pullall = "find . -mindepth 1 -maxdepth 1 -type d -exec git --git-dir={}/.git --work-tree=$PWD/{} pull origin master \\;";
-      myip = "curl ipinfo.io/ip";
-      ports = "netstat -t -u -l -a -n";
-      lg = "lazygit";
-      g = "git";
-    };
-
-    functions = {
-      mkcd = "function mkcd; if test (count $argv) -gt 0; mkdir $argv[1]; cd $argv[1]; end; end";
-      skub = "function skub; git pull; git add -A; if test (count $argv) -gt 0; git commit -m $argv[1]; else; git commit -m '.'; end; git push; end";
-      to = "function to; if test (count $argv) -gt 1; unoconv -f $argv[1] $argv[2]; else if test (count $argv) -eq 1; echo 'Need to specify file to convert....'; else; echo 'Need to specify what to convert to...'; end; end; end";
-    };
+    inherit shellAliases;
+    functions = functions.fish;
   };
 }

--- a/home-manager/config/fish.nix
+++ b/home-manager/config/fish.nix
@@ -1,6 +1,6 @@
 { ... }:
 let
-  inherit (import ./aliases.nix) shellAliases functions;
+  sharedAliases = import ./aliases.nix;
 in
 {
   programs.fish = {
@@ -20,7 +20,7 @@ in
       end
     '';
 
-    inherit shellAliases;
-    functions = functions.fish;
+    inherit (sharedAliases) shellAliases;
+    functions = sharedAliases.functions.fish;
   };
 }

--- a/home-manager/config/zsh.nix
+++ b/home-manager/config/zsh.nix
@@ -1,4 +1,6 @@
-args: {
+args: let
+  inherit (import ./aliases.nix) shellAliases functions;
+in {
   programs.zsh = {
     enable = false;
     enableCompletion = true;
@@ -26,82 +28,7 @@ args: {
         "1password"
       ];
     };
-
-    shellAliases = {
-      ##########################
-      ### Modifying existing ###
-      ##########################
-      sudo = ''sudo '';
-      mkdir = "mkdir -pv";
-      mv = "mv -iv";
-      cp = "cp -iv";
-      du = "ncdu --color dark -rr -x --exclude .git --exclude node_modules";
-      rm = ''trash'';
-      ping = "prettyping";
-      cat = "bat --theme Nord";
-      vim = ''nvim'';
-      vi = ''nvim'';
-      grep = ''rg --color = auto''; # Ripgrep
-      vscode = ''code'';
-      o = ''open'';
-
-      ######################
-      ### Custom aliases ###
-      ######################
-      zshconfig = "vi ~/.zshrc ; echo 'Sourcing zsh file' ; source ~/.zshrc";
-      neofetch = ''clear && neofetch | lolcat'';
-      cmatrix = ''cmatrix -C green'';
-      dots = "git -C $DOTFILES add -A ; git -C $DOTFILES commit -m 'Changed stuff' ; git -C $DOTFILES push";
-      reboot = ''sudo reboot'';
-      sl = ''sl | lolcat'';
-      cya = "dots ; sudo shutdown -h now";
-      up = "cd $DOTFILES && nix flake check && nix flake update && sudo darwin-rebuild switch --flake .#MacBook-Pro && cd -";
-      c = ''code'';
-      pullall = "find . -mindepth 1 -maxdepth 1 -type d -exec git --git-dir = {}/.git --work-tree = $PWD/{} pull origin master \;";
-      myip = "curl ipinfo.io/ip";
-      ports = "netstat -t -u -l -a -n";
-      lg = "lazygit";
-    };
-
-    initContent = ''
-      ############################
-      #Make folder and cd into it#
-      ############################
-      function mkcd() {
-          if [[ "$1" ]]; then
-              mkdir "$1" && cd "$1"
-          fi
-      }
-      #############
-      #Git command#
-      #############
-      function skub() {
-          git pull
-          git add -A
-
-          if [ "$1" != "" ]; then
-              git commit -m "$1"
-          else
-              git commit -m "."
-          fi
-          git push
-      }
-
-      ##############
-      #Convert file#
-      ##############
-      function to() {
-          if [ "$1" != "" ]; then
-              if [ "$2" != "" ]; then
-                  unoconv -f "$1" "$2"
-                  #rmf "$2"
-              else
-                  echo "Need to specify file to convert...."
-              fi
-          else
-              echo "Need to specify what to convert to..."
-          fi
-      }
-    '';
+    inherit shellAliases;
+    initContent = functions.zsh;
   };
 }

--- a/home-manager/config/zsh.nix
+++ b/home-manager/config/zsh.nix
@@ -1,6 +1,8 @@
-args: let
-  inherit (import ./aliases.nix) shellAliases functions;
-in {
+args:
+let
+  sharedAliases = import ./aliases.nix;
+in
+{
   programs.zsh = {
     enable = false;
     enableCompletion = true;
@@ -28,7 +30,7 @@ in {
         "1password"
       ];
     };
-    inherit shellAliases;
-    initContent = functions.zsh;
+    inherit (sharedAliases) shellAliases;
+    initContent = sharedAliases.functions.zsh;
   };
 }


### PR DESCRIPTION
## Summary
- move shell aliases and functions into new `aliases.nix`
- import shared aliases/functions into `fish.nix` and `zsh.nix`

## Testing
- `nix flake check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895c35602a883339a820ae65e2b510c